### PR TITLE
Skip LVS configuration without member

### DIFF
--- a/octavia/common/jinja/lvs/templates/macros.j2
+++ b/octavia/common/jinja/lvs/templates/macros.j2
@@ -110,7 +110,15 @@ TCP_CHECK {
         {%- set has_vip.found = True %}
     {%- endif %}
 {%- endfor %}
-{% if has_vip.found %}
+{%- set has_member = namespace(found=False) %}
+{%- if default_pool.enabled %}
+    {%- for member in default_pool.members %}
+        {%- if member.ip_version == ip_version %}
+            {%- set has_member.found = True %}
+        {%- endif %}
+    {%- endfor %}
+{%- endif %}
+{% if has_vip.found and has_member.found %}
 virtual_server_group ipv{{ ip_version }}-group {
     {% for vip in vips %}
     {% if vip.ip_version == ip_version %}


### PR DESCRIPTION
If a LVS virtual server has not backend with the matching IP protocol version the configuration must be skipped. Otherwise a virtual server without member would be created. This causes the amphora-agent to fail.

Change-Id: I6124af3d93a8d10ac38f4ac7b0c828a6e4e32a59